### PR TITLE
Add MDNF stats flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@ go run ./cmd/spath matrix -in examples/x.json
 go run ./cmd/spath mdnf   -in examples/x.gexp
 go run ./cmd/spath mdnf   -in examples/x.json
 ```
+
+# Метрики
+Добавьте `--stats` к команде `mdnf`, чтобы увидеть краткие метрики в stderr, или `--stats-json file.json` — чтобы сохранить полный объект Stats в JSON.


### PR DESCRIPTION
## Summary
- add `--stats` and `--stats-json` flags to `mdnf` subcommand to expose enumeration metrics
- document new metrics flags in README

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/github.com/hdalab/ga/@v/v0.1.1.zip": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3a1f7e74832390f143f8c3647735