### PR TITLE
Refactor utilities, add tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - run: go fmt ./...
+      - run: go vet ./...
+      - run: go test ./...

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # graph-exp — demo & CLI
 
-Demo/CLI for the `github.com/hdalab/ga` module.
+Demo/CLI for the [`github.com/hdalab/ga`](https://github.com/hdalab/ga) module.
+This repository is locked to [ga v0.1.3](https://github.com/hdalab/ga/releases/tag/v0.1.3).
 Specs may be written either in the original Gexp format or in JSON.
 
 ## Commands
@@ -11,5 +12,31 @@ go run ./cmd/spath mdnf   -in examples/x.gexp
 go run ./cmd/spath mdnf   -in examples/x.json
 ```
 
-# Метрики
-Добавьте `--stats` к команде `mdnf`, чтобы увидеть краткие метрики в stderr, или `--stats-json file.json` — чтобы сохранить полный объект Stats в JSON.
+## Metrics
+The `mdnf` command can report search metrics. Add `--stats` to print a short summary
+or `--stats-json stats.json` to write the full `Stats` structure to a file.
+
+Available fields include:
+- `NodesExpanded` — how many nodes were expanded during search
+- `Pruned` — how many branches were pruned
+- `NsPerPath` — average time per path
+
+Example:
+```bash
+go run ./cmd/spath mdnf -in examples/x.json --stats --stats-json stats.json
+```
+Sample `--stats` output:
+```
+stats: file=examples/x.json n=6 m=9 s=0 t=5 paths=3 expanded=10 pruned=2 elapsed=1.2ms (0.4µs/path)
+```
+And `stats.json` will contain something like:
+```json
+{
+  "NumPaths": 3,
+  "NodesExpanded": 10,
+  "Pruned": 2,
+  "ElapsedNS": 1200000,
+  "NsPerPath": 400
+}
+```
+These metrics help interpret performance: `NodesExpanded` and `Pruned` reflect search effort, while `NsPerPath` shows average time spent per discovered path.

--- a/cmd/spath/main.go
+++ b/cmd/spath/main.go
@@ -5,29 +5,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"os"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/hdalab/ga"
+	util "github.com/hdalab/graph-exp/internal/util"
 )
-
-func humanDur(ns int64) string {
-	if ns < 1_000 { // < 1µs
-		return fmt.Sprintf("%dns", ns)
-	}
-	if ns < 1_000_000 { // < 1ms
-		return fmt.Sprintf("%dµs", ns/1_000)
-	}
-	if ns < 1_000_000_000 { // < 1s
-		return fmt.Sprintf("%dms", ns/1_000_000)
-	}
-	// секунды с десятыми
-	s := float64(ns) / 1_000_000_000.0
-	return fmt.Sprintf("%.1fs", s)
-}
 
 func main() {
 	if len(os.Args) < 2 {
@@ -39,10 +22,10 @@ func main() {
 		in := fs.String("in", "", "input .gexp or .json file")
 		_ = fs.Parse(os.Args[2:])
 		must(*in != "", "-in required")
-		spec, err := readSpec(*in)
+		spec, err := util.ReadSpec(*in)
 		mustErr(err)
 		ms := ga.StructuralMatrix(&spec.G)
-		printMatrix(os.Stdout, ms)
+		util.PrintMatrix(os.Stdout, ms)
 	case "mdnf":
 		fs := flag.NewFlagSet("mdnf", flag.ExitOnError)
 		in := fs.String("in", "", "input .gexp or .json file")
@@ -50,7 +33,7 @@ func main() {
 		statsJSON := fs.String("stats-json", "", "write stats to JSON file")
 		_ = fs.Parse(os.Args[2:])
 		must(*in != "", "-in required")
-		spec, err := readSpec(*in)
+		spec, err := util.ReadSpec(*in)
 		mustErr(err)
 		var paths []ga.Path
 		start := time.Now()
@@ -60,7 +43,7 @@ func main() {
 			return true
 		})
 		mustErr(err)
-		// дозаполняем время при необходимости
+		// fill stats if elapsed not set
 		measuredNS := time.Since(start).Nanoseconds()
 		if stats.ElapsedNS == 0 {
 			stats.ElapsedNS = measuredNS
@@ -82,7 +65,7 @@ func main() {
 				}
 				fmt.Fprintf(os.Stderr,
 					"stats: file=%s n=%d m=%d s=%d t=%d paths=%d expanded=%d pruned=%d elapsed=%s%s\n",
-					file, n, m, spec.S, spec.T, stats.NumPaths, stats.NodesExpanded, stats.Pruned, humanDur(stats.ElapsedNS), perPath)
+					file, n, m, spec.S, spec.T, stats.NumPaths, stats.NodesExpanded, stats.Pruned, util.HumanDur(stats.ElapsedNS), perPath)
 			}
 			if *statsJSON != "" {
 				b, err := json.MarshalIndent(stats, "", "  ")
@@ -105,73 +88,17 @@ func usage() {
 	fmt.Fprintf(os.Stderr, "Usage:\n  spath matrix -in examples/x.gexp\n  spath matrix -in examples/x.json\n  spath mdnf -in examples/x.gexp\n  spath mdnf -in examples/x.json\n")
 	os.Exit(2)
 }
+
 func must(cond bool, msg string) {
 	if !cond {
 		fmt.Fprintln(os.Stderr, msg)
 		os.Exit(1)
 	}
 }
+
 func mustErr(err error) {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
 		os.Exit(1)
-	}
-}
-
-func readSpec(path string) (*ga.Spec, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	if json.Valid(data) {
-		return ga.ParseJson(data)
-	}
-	return ga.ParseGexp(data)
-}
-
-func printMatrix(w io.Writer, ms ga.Structural) {
-	n := len(ms)
-
-	// ширина номера строки (0..n-1)
-	idxw := len(strconv.Itoa(n - 1))
-
-	// ширина ячейки = макс(длина меток/0)
-	cellw := 1
-	for i := 0; i < n; i++ {
-		for j := 0; j < n; j++ {
-			s := ms[i][j]
-			if s == "" {
-				s = "0"
-			}
-			if l := len(s); l > cellw {
-				cellw = l
-			}
-		}
-	}
-
-	// шапка
-	fmt.Fprint(w, strings.Repeat(" ", idxw+3)) // место под "i [ "
-	for j := 0; j < n; j++ {
-		if j > 0 {
-			fmt.Fprint(w, "  ")
-		}
-		fmt.Fprintf(w, "%*d", cellw, j)
-	}
-	fmt.Fprintln(w)
-
-	// строки
-	for i := 0; i < n; i++ {
-		fmt.Fprintf(w, "%*d [ ", idxw, i)
-		for j := 0; j < n; j++ {
-			if j > 0 {
-				fmt.Fprint(w, "  ")
-			}
-			s := ms[i][j]
-			if s == "" {
-				s = "0"
-			}
-			fmt.Fprintf(w, "%*s", cellw, s)
-		}
-		fmt.Fprintln(w, " ]")
 	}
 }

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
-github.com/hdalab/ga v0.1.1 h1:8tlazbo9OdU5vCoN5xtUOv07uk0QUd2n38ozEzCQrRM=
-github.com/hdalab/ga v0.1.1/go.mod h1:1aM/HCfLLnaHwQMB/DI6YfyCY+xIjt9WHs/rFSnOXyA=
-github.com/hdalab/ga v0.1.2 h1:SMIYDUU/ucNntFdbk97anhkU5JGZtsZf27/6S/TtlM4=
-github.com/hdalab/ga v0.1.2/go.mod h1:1aM/HCfLLnaHwQMB/DI6YfyCY+xIjt9WHs/rFSnOXyA=
 github.com/hdalab/ga v0.1.3 h1:gRRkgiSMoO4MA2pYXk2xxv1WtQ6S7ceJoxKCCLIY+WI=
 github.com/hdalab/ga v0.1.3/go.mod h1:1aM/HCfLLnaHwQMB/DI6YfyCY+xIjt9WHs/rFSnOXyA=

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,0 +1,88 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/hdalab/ga"
+)
+
+// HumanDur converts nanoseconds to a short human-readable string.
+func HumanDur(ns int64) string {
+	if ns < 1_000 { // < 1µs
+		return fmt.Sprintf("%dns", ns)
+	}
+	if ns < 1_000_000 { // < 1ms
+		return fmt.Sprintf("%dµs", ns/1_000)
+	}
+	if ns < 1_000_000_000 { // < 1s
+		return fmt.Sprintf("%dms", ns/1_000_000)
+	}
+	// seconds with one decimal place
+	s := float64(ns) / 1_000_000_000.0
+	return fmt.Sprintf("%.1fs", s)
+}
+
+// ReadSpec loads a graph specification from either Gexp or JSON format.
+func ReadSpec(path string) (*ga.Spec, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if json.Valid(data) {
+		return ga.ParseJson(data)
+	}
+	return ga.ParseGexp(data)
+}
+
+// PrintMatrix renders a structural matrix to the given writer.
+func PrintMatrix(w io.Writer, ms ga.Structural) {
+	n := len(ms)
+
+	// width of row number (0..n-1)
+	idxw := len(strconv.Itoa(n - 1))
+
+	// width of cell = max(len(label),1)
+	cellw := 1
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			s := ms[i][j]
+			if s == "" {
+				s = "0"
+			}
+			if l := len(s); l > cellw {
+				cellw = l
+			}
+		}
+	}
+
+	// header
+	fmt.Fprint(w, strings.Repeat(" ", idxw+3)) // space for "i [ "
+	for j := 0; j < n; j++ {
+		if j > 0 {
+			fmt.Fprint(w, "  ")
+		}
+		fmt.Fprintf(w, "%*d", cellw, j)
+	}
+	fmt.Fprintln(w)
+
+	// rows
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(w, "%*d [ ", idxw, i)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				fmt.Fprint(w, "  ")
+			}
+			s := ms[i][j]
+			if s == "" {
+				s = "0"
+			}
+			fmt.Fprintf(w, "%*s", cellw, s)
+		}
+		fmt.Fprintln(w, " ]")
+	}
+}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,0 +1,60 @@
+package util
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/hdalab/ga"
+)
+
+func TestHumanDur(t *testing.T) {
+	cases := []struct {
+		ns   int64
+		want string
+	}{
+		{500, "500ns"},
+		{15_000, "15µs"},
+		{2_500_000, "2ms"},
+		{1_500_000_000, "1.5s"},
+	}
+	for _, c := range cases {
+		if got := HumanDur(c.ns); got != c.want {
+			t.Errorf("HumanDur(%d)=%s want %s", c.ns, got, c.want)
+		}
+	}
+}
+
+func TestReadSpec(t *testing.T) {
+	gexp, err := ReadSpec("../../examples/x.gexp")
+	if err != nil {
+		t.Fatalf("ReadSpec gexp: %v", err)
+	}
+	jsonSpec, err := ReadSpec("../../examples/x.json")
+	if err != nil {
+		t.Fatalf("ReadSpec json: %v", err)
+	}
+	if !reflect.DeepEqual(gexp, jsonSpec) {
+		t.Fatalf("specs differ: %#v vs %#v", gexp, jsonSpec)
+	}
+}
+
+func TestPrintMatrix(t *testing.T) {
+	spec, err := ReadSpec("../../examples/x.gexp")
+	if err != nil {
+		t.Fatalf("ReadSpec: %v", err)
+	}
+	ms := ga.StructuralMatrix(&spec.G)
+	var buf bytes.Buffer
+	PrintMatrix(&buf, ms)
+	want := "    0  1  2  3  4  5\n" +
+		"0 [ 0  a  b  0  0  0 ]\n" +
+		"1 [ 0  0  c  d  0  0 ]\n" +
+		"2 [ 0  0  0  e  f  i ]\n" +
+		"3 [ 0  0  0  0  g  0 ]\n" +
+		"4 [ 0  0  0  0  0  h ]\n" +
+		"5 [ 0  0  0  0  0  0 ]\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("PrintMatrix:\n%s\nwant:\n%s", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- move reusable helpers into `internal/util`
- add tests for duration formatting, spec reading and matrix printing
- configure GitHub Actions to run go fmt/vet/test
- document metrics and dependency on ga v0.1.3

## Testing
- `GOPROXY=direct go mod tidy` *(fails: unable to access github.com/hdalab/ga)*
- `go fmt ./...`
- `go vet ./...` *(fails: Get https://proxy.golang.org/...: Forbidden)*
- `go test ./...` *(fails: Get https://proxy.golang.org/...: Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68aa4fc5506c8323af4bedc66635dec8