### PR TITLE
Add path enumeration limits and output options

### DIFF
--- a/cmd/spath/main.go
+++ b/cmd/spath/main.go
@@ -140,14 +140,14 @@ func main() {
 			}
 			if *statsJSON != "" {
 				type statsOut struct {
-					ga.EnumStats
+					ga.Stats
 					StartedAt    string `json:"startedAt"`
 					FinishedAt   string `json:"finishedAt"`
 					TimedOut     bool   `json:"timedOut"`
 					LimitReached bool   `json:"limitReached"`
 				}
 				sj := statsOut{
-					EnumStats:    stats,
+					Stats:        stats,
 					StartedAt:    start.Format(time.RFC3339),
 					FinishedAt:   finish.Format(time.RFC3339),
 					TimedOut:     timedOut,

--- a/cmd/spath/main.go
+++ b/cmd/spath/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -25,20 +26,58 @@ func main() {
 	case "mdnf":
 		var statsFlag *bool
 		var statsJSON *string
+		var countOnly *bool
+		var maxPaths *int
+		var timeout *time.Duration
+		var outFile *string
+		var quiet bool
 		spec, in := parseSpec("mdnf", os.Args[2:], func(fs *flag.FlagSet) {
 			statsFlag = fs.Bool("stats", false, "print stats to stderr")
 			statsJSON = fs.String("stats-json", "", "write stats to JSON file")
+			countOnly = fs.Bool("count", false, "only print number of terms/paths")
+			maxPaths = fs.Int("max-paths", 0, "stop after enumerating N paths (0 for no limit)")
+			timeout = fs.Duration("timeout", 0, "stop after duration (e.g. 2s, 500ms)")
+			outFile = fs.String("o", "", "write MDNF result to file")
+			fs.BoolVar(&quiet, "q", false, "suppress regular output")
+			fs.BoolVar(&quiet, "quiet", false, "suppress regular output")
 		})
-		var paths []ga.Path
+
 		start := time.Now()
 		ctx := context.Background()
+		if *timeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, *timeout)
+			defer cancel()
+		}
+
+		var paths []ga.Path
+		var numPaths int
+		var limitReached bool
+		var timedOut bool
 		stats, err := ga.EnumerateMDNF(ctx, &spec.G, spec.S, spec.T, ga.EnumOptions{}, func(p ga.Path) bool {
-			paths = append(paths, p)
+			if ctx.Err() != nil {
+				timedOut = true
+				return false
+			}
+			numPaths++
+			if !*countOnly {
+				paths = append(paths, p)
+			}
+			if *maxPaths > 0 && numPaths >= *maxPaths {
+				limitReached = true
+				return false
+			}
 			return true
 		})
-		mustErr(err)
-		// заполнить статистику, если время не задано
-		measuredNS := time.Since(start).Nanoseconds()
+		if err != nil && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+			mustErr(err)
+		}
+		if ctx.Err() != nil {
+			timedOut = true
+		}
+
+		finish := time.Now()
+		measuredNS := finish.Sub(start).Nanoseconds()
 		if stats.ElapsedNS == 0 {
 			stats.ElapsedNS = measuredNS
 			if stats.NumPaths > 0 {
@@ -46,7 +85,39 @@ func main() {
 			}
 		}
 
-		fmt.Fprintln(os.Stdout, ga.MDNF(paths))
+		if !quiet {
+			if *countOnly {
+				if *outFile != "" {
+					if err := os.WriteFile(*outFile, []byte(fmt.Sprintf("%d\n", numPaths)), 0644); err != nil {
+						fmt.Fprintf(os.Stderr, "write -o: %v\n", err)
+						os.Exit(1)
+					}
+				}
+				fmt.Fprintln(os.Stdout, numPaths)
+			} else {
+				mdnf := ga.MDNF(paths)
+				fmt.Fprintln(os.Stdout, mdnf)
+				if *outFile != "" {
+					if err := os.WriteFile(*outFile, []byte(mdnf+"\n"), 0644); err != nil {
+						fmt.Fprintf(os.Stderr, "write -o: %v\n", err)
+						os.Exit(1)
+					}
+				}
+			}
+		} else if *outFile != "" {
+			if *countOnly {
+				if err := os.WriteFile(*outFile, []byte(fmt.Sprintf("%d\n", numPaths)), 0644); err != nil {
+					fmt.Fprintf(os.Stderr, "write -o: %v\n", err)
+					os.Exit(1)
+				}
+			} else {
+				mdnf := ga.MDNF(paths)
+				if err := os.WriteFile(*outFile, []byte(mdnf+"\n"), 0644); err != nil {
+					fmt.Fprintf(os.Stderr, "write -o: %v\n", err)
+					os.Exit(1)
+				}
+			}
+		}
 
 		if *statsFlag || *statsJSON != "" {
 			file := in
@@ -57,12 +128,32 @@ func main() {
 				if stats.NumPaths > 0 && stats.NsPerPath > 0 {
 					perPath = fmt.Sprintf(" (%.1fµs/path)", stats.NsPerPath/1_000.0)
 				}
-				fmt.Fprintf(os.Stderr,
-					"stats: file=%s n=%d m=%d s=%d t=%d paths=%d expanded=%d pruned=%d elapsed=%s%s\n",
+				msg := fmt.Sprintf("stats: file=%s n=%d m=%d s=%d t=%d paths=%d expanded=%d pruned=%d elapsed=%s%s",
 					file, n, m, spec.S, spec.T, stats.NumPaths, stats.NodesExpanded, stats.Pruned, util.HumanDur(stats.ElapsedNS), perPath)
+				if limitReached {
+					msg += fmt.Sprintf(" truncated at %d", *maxPaths)
+				}
+				if timedOut {
+					msg += " timed out"
+				}
+				fmt.Fprintln(os.Stderr, msg)
 			}
 			if *statsJSON != "" {
-				b, err := json.MarshalIndent(stats, "", "  ")
+				type statsOut struct {
+					ga.EnumStats
+					StartedAt    string `json:"startedAt"`
+					FinishedAt   string `json:"finishedAt"`
+					TimedOut     bool   `json:"timedOut"`
+					LimitReached bool   `json:"limitReached"`
+				}
+				sj := statsOut{
+					EnumStats:    stats,
+					StartedAt:    start.Format(time.RFC3339),
+					FinishedAt:   finish.Format(time.RFC3339),
+					TimedOut:     timedOut,
+					LimitReached: limitReached,
+				}
+				b, err := json.MarshalIndent(sj, "", "  ")
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "write --stats-json: %v\n", err)
 					os.Exit(1)

--- a/cmd/spath/main_test.go
+++ b/cmd/spath/main_test.go
@@ -104,7 +104,7 @@ func TestMDNFCount(t *testing.T) {
 // TestMDNFMaxPaths проверяет усечение по флагу -max-paths.
 func TestMDNFMaxPaths(t *testing.T) {
 	out, err := runCmd(t, "mdnf", "-in", "../../examples/x.json", "-max-paths", "1")
-	first := strings.Split(expectedMDNF(t), "|")[0] + "\n"
+	first := strings.TrimSpace(strings.Split(expectedMDNF(t), "|")[0]) + "\n"
 	if out != first {
 		t.Fatalf("max-paths output=%s want=%s", out, first)
 	}

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -49,6 +49,14 @@ The `mdnf` command forms the minimal disjunctive normal form of paths between `s
 go run ./cmd/spath mdnf -in examples/x.json --stats
 ```
 
+Additional useful flags:
+
+- `-count` – print only the number of terms/paths.
+- `-max-paths N` – stop after the first `N` paths.
+- `-timeout 2s` – abort enumeration after the given duration.
+- `-o FILE` – save the resulting MDNF to `FILE`.
+- `-q`, `--quiet` – suppress normal output (useful together with `--stats`).
+
 Example expression:
 
 ```
@@ -79,6 +87,8 @@ Available fields include:
 - `NodesExpanded` — how many nodes were expanded during search
 - `Pruned` — how many branches were pruned
 - `NsPerPath` — average time per path
+- `startedAt` / `finishedAt` — timestamps of enumeration (RFC3339)
+- `timedOut` / `limitReached` — flags indicating early termination
 
 Example:
 

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -49,6 +49,14 @@ go run ./cmd/spath matrix -in examples/x.json
 go run ./cmd/spath mdnf -in examples/x.json --stats
 ```
 
+Дополнительные флаги:
+
+- `-count` — вывести только число термов/путей.
+- `-max-paths N` — остановиться после первых `N` решений.
+- `-timeout 2s` — прервать поиск по истечении времени.
+- `-o FILE` — сохранить МДНФ в файл `FILE`.
+- `-q`, `--quiet` — подавить обычный вывод (оставить только статистику).
+
 Пример выражения:
 
 ```
@@ -77,6 +85,8 @@ Available fields include:
 - `NodesExpanded` — how many nodes were expanded during search
 - `Pruned` — how many branches were pruned
 - `NsPerPath` — average time per path
+- `startedAt` / `finishedAt` — временные метки (RFC3339)
+- `timedOut` / `limitReached` — признаки досрочного завершения
 
 Example:
 ```bash


### PR DESCRIPTION
## Summary
- add `-count`, `-max-paths`, `-timeout`, `-o`, and `-q/--quiet` flags for the `mdnf` subcommand
- record start/end times plus `timedOut` and `limitReached` in `--stats-json`
- document new flags and stats fields

## Testing
- `go test ./...` *(fails: github.com/hdalab/ga@v0.1.3: Get "https://proxy.golang.org/github.com/hdalab/ga/@v/v0.1.3.zip": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5e9fa0b483239611992fcab2822c